### PR TITLE
UI Improvements and min = 0 bugfix

### DIFF
--- a/assets/css/rangeslider.css
+++ b/assets/css/rangeslider.css
@@ -29,6 +29,9 @@
     display: flex;
     x-justify-content: space-around;
     x-align-items: stretch;
+    padding: .45em;
+    border: 2px solid #ddd;
+    background: #fff;
 }
 
     .rangeslider-slider-wrapper {

--- a/rangeslider.php
+++ b/rangeslider.php
@@ -202,8 +202,8 @@ class RangeSliderField extends InputField
         /* Set data attributes */
         $input->data(array(
             'field'   => 'rangesliderfield',
-            'min'     => $this->option('min') == 0 || $this->option('min') == false ? 0 : $this->option('min'),
-            'max'     => $this->option('max'),
+            'min'     => (int) $this->option('min'),
+            'max'     => (int) $this->option('max'),
             'step'    => $this->option('step'),
             'prefix'  => $this->option('prefix'),
             'postfix' => $this->option('postfix'),

--- a/rangeslider.php
+++ b/rangeslider.php
@@ -198,10 +198,11 @@ class RangeSliderField extends InputField
 
         $input->addClass('input-is-readonly');
 
+
         /* Set data attributes */
         $input->data(array(
             'field'   => 'rangesliderfield',
-            'min'     => $this->option('min'),
+            'min'     => $this->option('min') == 0 || $this->option('min') == false ? 0 : $this->option('min'),
             'max'     => $this->option('max'),
             'step'    => $this->option('step'),
             'prefix'  => $this->option('prefix'),

--- a/rangeslider.php
+++ b/rangeslider.php
@@ -27,17 +27,17 @@ class RangeSliderField extends InputField
      *
      * @var array
      */
-    public static $assets = array(
-        'css' => array(
+    public static $assets = [
+        'css' => [
             'nouislider-8.1.0.min.css',
             'rangeslider.css',
-        ),
-        'js' => array(
+        ],
+        'js' => [
             'nouislider-8.1.0.min.js',
             'wnumb-1.0.2.min.js',
             'rangeslider.js',
-        ),
-    );
+        ],
+    ];
 
     /**
      * Minimum value.
@@ -184,7 +184,7 @@ class RangeSliderField extends InputField
         $input = new Brick('input');
 
         /* Set general attributes */
-        $input->attr(array(
+        $input->attr([
             'type'         => 'text',
             'name'         => $this->name(),
             'id'           => $this->id(),
@@ -194,20 +194,19 @@ class RangeSliderField extends InputField
             'tabindex'     => '-1',
             'disabled'     => $this->option('disabled'),
             'readonly'     => $this->option('readonly'),
-        ));
+        ]);
 
         $input->addClass('input-is-readonly');
 
-
         /* Set data attributes */
-        $input->data(array(
+        $input->data([
             'field'   => 'rangesliderfield',
             'min'     => $this->option('min') == 0 || $this->option('min') == false ? 0 : $this->option('min'),
             'max'     => $this->option('max') == 0 || $this->option('max') == false ? 0 : $this->option('max'),
             'step'    => $this->option('step'),
             'prefix'  => $this->option('prefix'),
             'postfix' => $this->option('postfix'),
-        ));
+        ]);
 
         return $input;
     }
@@ -236,7 +235,7 @@ class RangeSliderField extends InputField
      */
     public function content()
     {
-        $content = Tpl::load(__DIR__ . DS . 'partials' . DS . 'content.php', array('field' => $this));
+        $content = Tpl::load(__DIR__.DS.'partials'.DS.'content.php', ['field' => $this]);
 
         return $content;
     }

--- a/rangeslider.php
+++ b/rangeslider.php
@@ -202,8 +202,8 @@ class RangeSliderField extends InputField
         /* Set data attributes */
         $input->data(array(
             'field'   => 'rangesliderfield',
-            'min'     => (int) $this->option('min'),
-            'max'     => (int) $this->option('max'),
+            'min'     => $this->option('min') == 0 || $this->option('min') == false ? 0 : $this->option('min'),
+            'max'     => $this->option('max') == 0 || $this->option('max') == false ? 0 : $this->option('max'),
             'step'    => $this->option('step'),
             'prefix'  => $this->option('prefix'),
             'postfix' => $this->option('postfix'),


### PR DESCRIPTION
Happy new year 🎉

The range slider turns into an endless javascript reload loop when I set `min: 0`. So it seems like the plugin interprets the number `0` to false. Re-interpreting the value fixes this bug.

Also added a more Kirby-like "input field" look to it.
![bildschirmfoto 2016-01-02 um 13 02 11](https://cloud.githubusercontent.com/assets/980778/12074387/1583088e-b151-11e5-9a04-427c70ae6120.png)
